### PR TITLE
Add Kafka queue integration for inference data

### DIFF
--- a/.claude/commands/issues.md
+++ b/.claude/commands/issues.md
@@ -1,0 +1,41 @@
+You are an AI assistant tasked with creating well-structured GitHub issues for feature requests, bug reports, or improvement ideas. Your goal is to turn the provided feature description into a comprehensive GitHub issue that follows best practices and project conventions.
+
+First, you will be given a feature description and a repository URL. Here they are:
+
+<feature_description> #$ARGUMENTS </feature_description>
+
+Follow these steps to complete the task, make a todo list and think ultrahard:
+
+1. Research the repository:
+
+  – Visit the provided repo_url and examine the repository’s structure, existing issues, and documentation.
+  – Look for any CONTRIBUTING.md, ISSUE_TEMPLATE.md, or similar files that might contain guidelines for creating issues.
+  – Note the project’s coding style, naming conventions, and any specific requirements for submitting issues.
+
+2. Research best practices:
+
+  – Search for current best practices in writing GitHub issues, focusing on clarity, completeness, and actionability.
+  – Look for examples of well-written issues in popular open-source projects for inspiration.
+
+3. Present a plan:
+
+  – Based on your research, outline a plan for creating the GitHub issue.
+  – Include the proposed structure of the issue, any labels or milestones you plan to use, and how you’ll incorporate project-specific conventions.
+  – Present this plan in <plan> tags.
+  – Include the reference link to featurebase or any other link that has the source of the user request
+
+4. Create the GitHub issue:
+
+  – Once the plan is approved, draft the GitHub issue content.
+  – Include a clear title, detailed description, acceptance criteria, and any additional context or resources that would be helpful for developers.
+  – Use appropriate formatting (e.g., Markdown) to enhance readability.
+  – Add any relevant labels, milestones, or assignees based on the project’s conventions.
+
+5. Final output:
+
+  – Present the complete GitHub issue content in <github_issue> tags.
+  – Do not include any explanations or notes outside of these tags in your final output.
+
+Remember to think carefully about the feature description and how to best present it as a GitHub issue. Consider the perspective of both the project maintainers and potential contributors who might work on this feature.
+
+Your final output should consist of only the content within the <github_issue> tags, ready to be copied and pasted directly into GitHub. Make sure to use the GitHub CLI `gh issue create` to create the actual issue after you generate. Assign either the label `bug` or `enhancement` based on the nature of the issue.

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -1,0 +1,32 @@
+You are an experienced software developer tasked with addressing a GitHub issue. Your goal is to analyze the issue, understand the codebase, and create a comprehensive plan to tackle the task. Follow these steps carefully:
+
+1. First, review the GitHub issue:
+
+<github_issue> #$ARGUMENTS </github_issue>
+
+2. Next, examine the relevant parts of the codebase.
+
+Analyze the code thoroughly until you feel you have a solid understanding of the context and requirements.
+
+3. Create a new branch from the main branch for this feature. The branch name should be descriptive and relate to the issue. Use the following format: feature/[issue-number]-brief-description
+
+4. Create a comprehensive plan and todo list for addressing the issue. Consider the following aspects:
+
+   – Required code changes  
+   – Potential impacts on other parts of the system  
+   – Necessary tests to be written or updated  
+   – Documentation updates  
+   – Performance considerations  
+   – Security implications  
+   – Backwards compatibility (if applicable)  
+   – Include the reference link to featurebase or any other link that has the source of the user request
+
+5. Think deeply about all aspects of the task. Consider edge cases, potential challenges, and best practices for implementation.
+
+6. Present your plan in the following format:
+
+<plan>  
+[Your comprehensive plan goes here. Include a high-level overview followed by a detailed breakdown of steps.]  
+</plan>
+
+Remember, your task is to create a plan, not to implement the changes. Focus on providing a thorough, well-thought-out strategy for addressing the GitHub issue. Then ASK FOR APPROVAL BEFORE YOU START WORKING ON THE TODO LIST.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,467 @@
+name: PR Checks
+
+on:
+  merge_group:
+  pull_request:
+    branches: ["release"]
+
+env:
+  FORCE_COLOR: 1
+  TENSORZERO_CLICKHOUSE_URL: "http://chuser:chpassword@localhost:8123/tensorzero"
+
+jobs:
+  clickhouse-tests-cloud:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cloud_instance:
+          - release_channel: regular
+            url_secret: CLICKHOUSE_CLOUD_URL
+          - release_channel: fast
+            url_secret: CLICKHOUSE_CLOUD_FAST_CHANNEL_URL
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          cache-provider: "buildjet"
+          save-if: ${{ github.event_name == 'merge_group' }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
+        with:
+          tool: cargo-nextest
+
+      - name: Set up TENSORZERO_CLICKHOUSE_URL
+        run: |
+          echo "TENSORZERO_CLICKHOUSE_URL=${{ secrets[matrix.cloud_instance.url_secret] }}" >> $GITHUB_ENV
+
+      - name: Wake up ClickHouse cloud
+        run: |
+          curl $TENSORZERO_CLICKHOUSE_URL --data-binary 'SHOW DATABASES'
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: Download ClickHouse fixtures
+        run: uv run ./ui/fixtures/download-fixtures.py
+
+      - name: Delete old ClickHouse cloud dbs
+        run: ./ci/delete-clickhouse-dbs.sh
+
+      # We run this as a separate step so that we can see live build logs
+      # (and fail the job immediately if the build fails)
+      - name: Build the gateway for E2E tests
+        run: cargo build-e2e
+
+      - name: Launch the gateway for E2E tests
+        run: |
+          cargo run-e2e > e2e_logs.txt 2>&1 &
+            count=0
+            max_attempts=30
+            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
+              echo "Waiting for gateway to be healthy..."
+              sleep 1
+              count=$((count + 1))
+              if [ $count -ge $max_attempts ]; then
+                echo "Gateway failed to become healthy after $max_attempts attempts"
+                exit 1
+              fi
+            done
+          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
+
+      - name: Test (Rust)
+        # This test causes a huge slowdown on ClickHouse cloud, even though it uses a fresh database
+        # For now, let's skip it (we still run it in the local docker ClickHouse tests)
+        # See https://github.com/tensorzero/tensorzero/issues/2216
+        # Also, `test_clickhouse_migration_manager` is consistently taking a very long time (and timing out)
+        # on the fast release channel, so we temporarily skip it
+        run: |
+          if [ "${{ matrix.cloud_instance.release_channel }}" = "fast" ]; then
+            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations --skip test_clickhouse_migration_manager
+          else
+            cargo test-e2e-no-creds -- --skip test_concurrent_clickhouse_migrations
+          fi
+
+      - name: Print e2e logs
+        if: always()
+        run: cat e2e_logs.txt
+
+  check-docker-compose:
+    permissions:
+      # Permission to checkout the repository
+      contents: read
+      # Permission to fetch GitHub OIDC token authentication
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
+      - name: Install Namespace CLI
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      - name: Configure Namespace-powered Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      - name: Check all docker-compose.yml files
+        run: ./ci/check-all-docker-compose.sh
+
+  check-python-client-build:
+    uses: ./.github/workflows/python-client-build.yml
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          cache-provider: "buildjet"
+          save-if: ${{ github.event_name == 'merge_group' }}
+      - name: Build Rust
+        run: cargo build --workspace
+
+  validate:
+    runs-on: namespace-profile-tensorzero-8x16
+
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # We allow the namespace builder setup to fail on Dependabot PRs and PRs from forks
+      # (where the oidc token is not available)
+
+      - name: Install Namespace CLI
+        uses: namespacelabs/nscloud-setup@d1c625762f7c926a54bd39252efff0705fd11c64
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      - name: Configure Namespace-powered Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@84ca8c58fdf372d6a4750476cd09b7b96ee778ca
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
+
+      # We deliberately install our MSRV here (rather than 'stable') to ensure that everything compiles with that version
+      - name: Install Rust 1.85.0
+        run: |
+          rustup install 1.85.0 --component clippy,rustfmt
+          rustup default 1.85.0
+
+      - name: Print Rust version
+        run: rustc --version
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 10
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: Configure Namespace cache for Rust, Python (pip), and pnpm
+        uses: namespacelabs/nscloud-cache-action@2f50e7d0f70475e6f59a55ba0f05eec9108e77cc
+        with:
+          cache: |
+            pnpm
+            rust
+            uv
+
+      - name: check‑case‑conflict
+        run: uv run --with pre-commit pre-commit run check-case-conflict --all-files
+
+      - name: check‑executables‑have‑shebangs
+        run: uv run --with pre-commit pre-commit run check-executables-have-shebangs --all-files
+
+      - name: check‑json
+        run: uv run --with pre-commit pre-commit run check-json --all-files
+
+      - name: check‑yaml
+        run: uv run --with pre-commit pre-commit run check-yaml --all-files
+
+      - name: check‑toml
+        run: uv run --with pre-commit pre-commit run check-toml --all-files
+
+      - name: check‑xml
+        run: uv run --with pre-commit pre-commit run check-xml --all-files
+
+      - name: check‑merge‑conflict
+        run: uv run --with pre-commit pre-commit run check-merge-conflict --all-files
+
+      - name: check‑symlinks
+        run: uv run --with pre-commit pre-commit run check-symlinks --all-files
+
+      - name: check‑vcs‑permalinks
+        run: uv run --with pre-commit pre-commit run check-vcs-permalinks --all-files
+
+      - name: detect‑private‑key
+        run: uv run --with pre-commit pre-commit run detect-private-key --all-files
+
+      # We don't run these two because we want to allow template files to have trailing whitespace
+      # TODO: how do we exclude minijinja files using pre-commit in GHA?
+      # - name: end‑of‑file‑fixer
+      #   run: uv run --with pre-commit pre-commit run end-of-file-fixer
+
+      # - name: trailing‑whitespace
+      #   run: uv run --with pre-commit pre-commit run trailing-whitespace
+
+      - name: uv-lock
+        run: |
+          bash -c '
+          git ls-files "**/pyproject.toml" \
+            | while read f; do
+                dir=$(dirname "$f")
+                (cd "$dir" && uv lock --project="pyproject.toml")
+              done
+          '
+
+      - name: uv-export
+        run: |
+          bash -c '
+          git ls-files "**/pyproject.toml" \
+            | while read f; do
+                dir=$(dirname "$f")
+                (cd "$dir" && uv export --project="pyproject.toml" --output-file=requirements.txt --quiet)
+              done
+          '
+      - name: verify uv generated files
+        run: git diff --exit-code
+
+      # TODO: Enable this if we can figure out the invocation
+      # - name: Run nb-clean
+      #   run: uv run --with nb-clean nb-clean check --remove-empty-cells
+
+      - name: Install cargo-nextest, cargo-deny, and cargo-hack
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
+        with:
+          tool: cargo-nextest,cargo-deny,cargo-hack
+
+      - name: Build (Rust)
+        run: cargo build --workspace --verbose
+
+      - name: Lint (Rust)
+        run: |
+          cargo fmt -- --check
+          cargo hack clippy --all-targets --each-feature -- -D warnings
+
+      - name: Run cargo-deny
+        run: cargo deny check
+
+      - name: Test (Rust)
+        run: |
+          cargo test-unit ${{ vars.CARGO_NEXTEST_EXTRA_ARGS }}
+
+      - name: Install Python for python async client tests
+        run: uv python install 3.9
+
+      - name: Lint (Python:ruff)
+        run: |
+          uvx ruff@0.9.0 check --output-format=github --extend-select I .
+          uvx ruff@0.9.0 format --check .
+
+      - name: "Python: Pyo3 Client: Build and install dependencies"
+        working-directory: clients/python
+        run: |
+          uv venv
+          uv pip sync requirements.txt
+
+      - name: "Python: PyO3 Client: pyright"
+        working-directory: clients/python
+        run: |
+          uv pip install pyright==1.1.394
+          uv run pyright
+
+      - name: "Python: PyO3 Client: stubtest"
+        working-directory: clients/python
+        run: |
+          uv run stubtest tensorzero.tensorzero
+
+      - name: "Python: OpenAI Client: Install dependencies"
+        working-directory: clients/openai-python
+        run: |
+          uv venv
+          uv pip sync requirements.txt
+
+      - name: "Python: OpenAI Client: pyright"
+        working-directory: clients/openai-python
+        run: |
+          uv pip install pyright==1.1.394
+          uv run pyright
+
+      - name: "Node.js: OpenAI Client: Install dependencies"
+        working-directory: clients/openai-node
+        run: |
+          pnpm install
+
+      - name: "Node.js: Run prettier"
+        working-directory: clients/openai-node
+        run: pnpm run format
+
+      - name: "Node.js: OpenAI Client: typecheck"
+        working-directory: clients/openai-node
+        run: |
+          pnpm run typecheck
+
+      - name: "Node.js: OpenAI Client: lint"
+        working-directory: clients/openai-node
+        run: |
+          pnpm run lint
+
+      - name: "Python: Recipes: Install dependencies"
+        working-directory: recipes
+        run: |
+          uv venv
+          uv sync
+
+      - name: "Python: Recipes: pyright"
+        working-directory: recipes
+        run: |
+          uv run pyright
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
+        with:
+          node-version: "22.9.0"
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build minijinja WASM bindings
+        working-directory: ui/app/utils/minijinja
+        run: wasm-pack build --dev --features console_error_panic_hook
+
+      - name: Run minijinja WASM tests
+        working-directory: ui/app/utils/minijinja
+        run: wasm-pack test --node --features console_error_panic_hook
+
+      - name: Install dependencies
+        working-directory: ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Run ESLint
+        working-directory: ui
+        run: pnpm run lint
+
+      - name: Run Prettier
+        working-directory: ui
+        run: pnpm run format
+
+      - name: pnpm TypeScript type checking
+        working-directory: ui
+        run: pnpm run typecheck
+
+      - name: Compile / validate notebooks
+        run: ci/compile-check-notebooks.sh
+
+  clickhouse-tests:
+    # We don't run many tests here, so use a normal runner with Github Actions caching
+    # to avoid unnecessarily using Namespace credits (it should still always finish before
+    # the main 'validate' job)
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.clickhouse_version.allow_failure }}
+    strategy:
+      matrix:
+        clickhouse_version:
+          - tag: "24.12-alpine"
+            prefix: "24.12"
+            allow_failure: false
+          - tag: "25.2-alpine"
+            prefix: "25.2"
+            allow_failure: false
+          - tag: "latest-alpine"
+            prefix: ""
+            # ClickHouse can make new releases at any time, which might break our tests.
+            # We allow this job to fail to avoid blocking CI whenever this happens.
+            # However, we'll still want to fix the failing tests soon after we notice the failure
+            allow_failure: true
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+        with:
+          cache-provider: "buildjet"
+          save-if: ${{ github.event_name == 'merge_group' }}
+      - run: df -h
+      # ClickHouse intermittently runs out of disk space on the `ubuntu-latest` runner
+      # I'm using the commands from https://carlosbecker.com/posts/github-actions-disk-space/ to try to get more disk space
+      - name: "Free up disk space"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      - run: df -h
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@37bdc826eaedac215f638a96472df572feab0f9b
+        with:
+          tool: cargo-nextest
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
+
+      - name: Download ClickHouse fixtures
+        run: uv run ./ui/fixtures/download-fixtures.py
+
+      - name: Set up TENSORZERO_CLICKHOUSE_URL for E2E tests
+        run: |
+          echo "TENSORZERO_CLICKHOUSE_URL=http://chuser:chpassword@localhost:8123/tensorzero_e2e_tests" >> $GITHUB_ENV
+
+      - name: Launch ClickHouse container for E2E tests
+        run: TENSORZERO_CLICKHOUSE_VERSION=${{ matrix.clickhouse_version.tag }} docker compose -f tensorzero-internal/tests/e2e/docker-compose.yml up clickhouse --wait
+
+      # Make an HTTP request to ClickHouse and check that the version matches '${{ matrix.clickhouse_version }}'
+      - name: Check ClickHouse version
+        run: |
+          CLICKHOUSE_VERSION=$(curl -s "http://localhost:8123/query?user=chuser&password=chpassword" --data-binary "SELECT version()")
+          echo "Detected ClickHouse version: $CLICKHOUSE_VERSION"
+          echo "$CLICKHOUSE_VERSION" | grep -q "${{ matrix.clickhouse_version.prefix }}" || echo "WARNING: ClickHouse version does not match expected ${{ matrix.clickhouse_version.prefix }}"
+
+      # We run this as a separate step so that we can see live build logs
+      # (and fail the job immediately if the build fails)
+      - name: Build the gateway for E2E tests
+        run: cargo build-e2e
+
+      - name: Launch the gateway for E2E tests
+        run: |
+          cargo run-e2e > e2e_logs.txt 2>&1 &
+            count=0
+            max_attempts=10
+            while ! curl -s -f http://localhost:3000/health >/dev/null 2>&1; do
+              echo "Waiting for gateway to be healthy..."
+              sleep 1
+              count=$((count + 1))
+              if [ $count -ge $max_attempts ]; then
+                echo "Gateway failed to become healthy after $max_attempts attempts"
+                exit 1
+              fi
+            done
+          echo "GATEWAY_PID=$!" >> $GITHUB_ENV
+
+      - name: Test (Rust)
+        run: cargo test-e2e-no-creds
+
+      - name: Print e2e logs
+        if: always()
+        run: cat e2e_logs.txt
+
+  build-gateway-container:
+    uses: ./.github/workflows/build-gateway-container.yml
+
+
+  # See 'ci/README.md' at the repository root for more details.
+  check-all-general-jobs-passed:
+    if: always()
+    needs:
+      [
+        clickhouse-tests-cloud,
+        check-docker-compose,
+        validate,
+        clickhouse-tests
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/docs/REDIS_AUTH_INTEGRATION.md
+++ b/docs/REDIS_AUTH_INTEGRATION.md
@@ -1,0 +1,237 @@
+# Redis and Authentication Integration in TensorZero
+
+## Overview
+
+TensorZero has integrated Redis for dynamic model configuration and API key-based authentication, enabling multi-tenant support and runtime configuration updates without service restarts. This integration allows the system to serve different models to different users based on their API keys.
+
+## Architecture Components
+
+### 1. Redis Client (`tensorzero-internal/src/redis_client.rs`)
+
+The Redis client manages real-time synchronization of model configurations and API keys:
+
+#### Key Patterns
+- `model_table:{model_id}` - Stores model provider configurations
+- `api_key:{api_key}` - Stores API key to model mappings
+
+#### Event Subscriptions
+- `__keyevent@*__:set` - Captures new/updated keys
+- `__keyevent@*__:del` - Captures deleted keys
+- `__keyevent@*__:expired` - Captures expired keys
+
+#### Initialization Flow
+1. On startup, fetches all existing `model_table:*` and `api_key:*` keys
+2. Subscribes to keyspace notifications for real-time updates
+3. Maintains connection with automatic reconnection logic
+
+### 2. Authentication Middleware (`tensorzero-internal/src/auth.rs`)
+
+The authentication system validates API keys and maps user-facing model names to internal model IDs:
+
+#### Request Flow
+1. Extracts API key from `Authorization` header (supports "Bearer" prefix)
+2. Validates key exists in the auth state
+3. Retrieves model mapping for the API key
+4. Modifies request body: replaces `model` field with `tensorzero::model_name::{model_id}`
+5. Passes modified request to downstream handlers
+
+#### Key Features
+- Thread-safe with RwLock for concurrent access
+- Dynamic updates without service restart
+- Graceful handling of missing keys
+
+### 3. Model Table (`tensorzero-internal/src/model_table.rs`)
+
+Manages model configurations and routing:
+
+#### Model Configuration Structure
+```json
+{
+  "model-id": {
+    "routing": ["provider1", "provider2"],
+    "providers": {
+      "provider1": {
+        "type": "vllm",
+        "model_name": "actual-model-name",
+        "api_base": "http://endpoint",
+        "api_key_location": "none"
+      }
+    }
+  }
+}
+```
+
+#### Validation
+- Prevents use of reserved prefixes (`tensorzero::`)
+- Validates model exists before returning configuration
+- Supports shorthand notation (e.g., `openai::gpt-4`)
+
+### 4. OpenAI-Compatible Endpoint (`tensorzero-internal/src/endpoints/openai_compatible.rs`)
+
+Handles the model resolution after authentication:
+
+#### Model Name Parsing
+- Detects `tensorzero::model_name::{model_id}` pattern
+- Extracts model ID for table lookup
+- Falls back to function name resolution if not a model reference
+
+## Data Flow
+
+### 1. Configuration Update Flow
+```
+Redis SET → Keyspace Event → Redis Client → Update In-Memory State
+```
+
+1. External system sets key in Redis (e.g., `api_key:xyz` or `model_table:abc`)
+2. Redis publishes keyspace notification
+3. Redis client receives event and fetches updated value
+4. Updates appropriate in-memory state (Auth or ModelTable)
+
+### 2. Request Authentication Flow
+```
+Client Request → Auth Middleware → Model Resolution → Provider
+```
+
+1. Client sends request with API key in Authorization header
+2. Auth middleware validates key and retrieves model mapping
+3. Modifies request to include internal model ID
+4. OpenAI endpoint resolves model ID to provider configuration
+5. Routes request to appropriate provider
+
+## Redis Data Structures
+
+### API Key Structure
+```json
+{
+  "api_key_here": {
+    "user-facing-model-name": "internal-model-id",
+    "another-model": "another-model-id"
+  }
+}
+```
+
+### Model Table Structure
+```json
+{
+  "model-id": {
+    "routing": ["primary-provider", "fallback-provider"],
+    "providers": {
+      "primary-provider": {
+        "type": "provider-type",
+        "model_name": "actual-model-name",
+        "api_base": "http://provider-endpoint",
+        "api_key_location": "header|none"
+      }
+    }
+  }
+}
+```
+
+## Configuration
+
+### Environment Variables
+- `TENSORZERO_REDIS_URL` - Redis connection string (e.g., `redis://default:password@localhost:6379`)
+
+### Gateway Integration
+The gateway initializes Redis when the environment variable is set:
+
+```rust
+if let Ok(redis_url) = std::env::var("TENSORZERO_REDIS_URL") {
+    if !redis_url.is_empty() {
+        let redis_client = RedisClient::new(&redis_url, app_state.clone(), auth.clone()).await;
+        redis_client.start().await.expect_pretty("Failed to start Redis client");
+    }
+}
+```
+
+## Testing
+
+A test script (`redis-test.py`) is provided for manual testing:
+
+```python
+import redis
+import json
+
+# Connect to Redis
+r = redis.Redis.from_url("redis://default:budpassword@localhost:6378")
+
+# Set model configuration
+models = {
+    "model-id": {
+        "routing": ["vllm"],
+        "providers": {
+            "vllm": {
+                "type": "vllm",
+                "model_name": "actual-model",
+                "api_base": "http://endpoint/v1",
+                "api_key_location": "none"
+            }
+        }
+    }
+}
+r.set("model_table:model-id", json.dumps(models))
+
+# Set API key mapping
+api_keys = {
+    "api_key_here": {
+        "gpt-4o": "model-id"
+    }
+}
+r.set("api_key:api_key_here", json.dumps(api_keys))
+```
+
+## Benefits
+
+1. **Dynamic Configuration**: Add/remove models and API keys without restarting the service
+2. **Multi-Tenancy**: Different API keys can access different models
+3. **Real-time Updates**: Changes take effect immediately via Redis pub/sub
+4. **Scalability**: Multiple gateway instances can share the same Redis backend
+5. **Isolation**: Each tenant's model access is isolated by their API key
+
+## Security Considerations
+
+1. **API Key Storage**: Keys are stored in Redis and should be properly secured
+2. **Redis Access**: Ensure Redis is not publicly accessible
+3. **TLS**: Use Redis TLS connections in production
+4. **Key Rotation**: API keys can be rotated by updating Redis entries
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Redis Connection Failed**
+   - Check `TENSORZERO_REDIS_URL` is correctly formatted
+   - Verify Redis is running and accessible
+   - Check network connectivity
+
+2. **API Key Not Working**
+   - Verify key exists in Redis with correct format
+   - Check model ID mapping is valid
+   - Ensure Redis events are enabled (`notify-keyspace-events` config)
+
+3. **Model Not Found**
+   - Verify model table entry exists in Redis
+   - Check model ID matches between API key mapping and model table
+   - Validate JSON structure in Redis
+
+### Debug Commands
+
+```bash
+# Check Redis keys
+redis-cli KEYS "api_key:*"
+redis-cli KEYS "model_table:*"
+
+# Get specific key value
+redis-cli GET "api_key:your_key_here"
+
+# Monitor Redis events
+redis-cli PSUBSCRIBE "__keyevent@*__:*"
+```
+
+## Future Enhancements
+
+1. **Metrics**: Track API key usage and model request patterns
+2. **Rate Limiting**: Per-API-key rate limits stored in Redis
+3. **Caching**: Cache model responses in Redis for common queries
+4. **Audit Logging**: Log all API key usage for compliance
+5. **Key Expiration**: Support automatic API key expiration

--- a/docs/kafka-integration.md
+++ b/docs/kafka-integration.md
@@ -1,0 +1,169 @@
+# Kafka Integration
+
+TensorZero supports sending inference data to Apache Kafka in addition to ClickHouse. This enables real-time streaming of inference events for downstream processing and integration with existing data pipelines.
+
+## Configuration
+
+Kafka integration is configured in the `[gateway.observability]` section of your TensorZero configuration file:
+
+```toml
+[gateway.observability]
+enabled = true
+async_writes = true
+
+[gateway.observability.kafka]
+enabled = true
+brokers = "localhost:9092"  # Comma-separated list of Kafka brokers
+topic_prefix = "tensorzero"  # Prefix for all Kafka topics
+
+# Optional settings
+compression_type = "lz4"  # Options: none, gzip, snappy, lz4, zstd
+batch_size = 1000  # Maximum number of messages to batch
+linger_ms = 10  # Time to wait for batching messages
+request_timeout_ms = 5000  # Request timeout in milliseconds
+
+# Optional SASL authentication
+[gateway.observability.kafka.sasl]
+mechanism = "PLAIN"  # Options: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+username = "your-username"
+password = "your-password"
+```
+
+## Topics
+
+When enabled, TensorZero writes to the following Kafka topics (prefixed with your configured `topic_prefix`):
+
+- `{topic_prefix}_model_inference` - Raw model provider responses
+- `{topic_prefix}_chat_inference` - Chat completion inference results  
+- `{topic_prefix}_json_inference` - JSON mode inference results
+
+## Message Format
+
+All messages are sent as JSON with the following structure:
+
+### Model Inference Message
+```json
+{
+  "id": "inference-uuid",
+  "inference_id": "parent-inference-uuid",
+  "raw_request": "...",
+  "raw_response": "...",
+  "input_messages": "...",
+  "output": "...",
+  "model_name": "gpt-4",
+  "model_provider_name": "openai",
+  "input_tokens": 100,
+  "output_tokens": 200,
+  "response_time_ms": 500,
+  "cached": false
+}
+```
+
+### Chat Inference Message
+```json
+{
+  "id": "inference-uuid",
+  "function_name": "chat_function",
+  "variant_name": "variant_a",
+  "episode_id": "episode-uuid",
+  "input": {...},
+  "output": [...],
+  "processing_time_ms": 123,
+  "tags": {"key": "value"}
+}
+```
+
+
+## Message Keys
+
+Messages use the following fields as Kafka message keys for partitioning:
+- `id` (primary)
+- `inference_id` (fallback)
+- `episode_id` (fallback)
+- `target_id` (fallback)
+
+## Non-blocking Writes
+
+Similar to ClickHouse, Kafka writes are non-blocking by default when `async_writes` is enabled. This ensures that:
+- Client requests are not delayed by Kafka writes
+- Failures in Kafka don't affect the main request flow
+- Messages are sent asynchronously using Tokio tasks
+
+Note: Feedback data is only written to ClickHouse and not sent to Kafka.
+
+## Error Handling
+
+- Connection failures during startup will prevent the gateway from starting if Kafka is enabled
+- Write failures are logged but don't fail the request
+- Serialization errors are tracked in metrics
+
+## Metrics
+
+The following metrics are exposed for monitoring Kafka operations:
+
+- `kafka_connections_established` - Counter of successful Kafka connections
+- `kafka_connection_errors` - Counter of connection failures
+- `kafka_writes_success` - Counter of successful writes (labeled by topic and data_type)
+- `kafka_writes_failed` - Counter of failed writes (labeled by topic and data_type)
+- `kafka_serialization_errors` - Counter of serialization failures
+- `kafka_write_duration_ms` - Histogram of write latencies (labeled by topic and data_type)
+
+## Running Kafka for Development
+
+For local development, you can run Kafka using Docker:
+
+```bash
+docker run -d --name kafka -p 9092:9092 \
+  -e KAFKA_NODE_ID=1 \
+  -e KAFKA_PROCESS_ROLES=broker,controller \
+  -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
+  -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
+  -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:9093 \
+  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
+  -e KAFKA_LOG_DIRS=/var/lib/kafka/data \
+  -e KAFKA_CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+  apache/kafka:3.7.0
+```
+
+## Consuming Messages
+
+You can consume messages using any Kafka client. Example using `kafka-console-consumer`:
+
+```bash
+# List all topics
+kafka-topics --bootstrap-server localhost:9092 --list
+
+# Consume from a specific topic
+kafka-console-consumer --bootstrap-server localhost:9092 \
+  --topic tensorzero_model_inference \
+  --from-beginning
+```
+
+## Best Practices
+
+1. **Topic Management**: Consider setting up topic auto-creation or pre-create topics with appropriate retention policies
+2. **Compression**: Use compression (lz4 recommended) to reduce network bandwidth
+3. **Batching**: Configure batch settings based on your throughput requirements
+4. **Monitoring**: Set up alerts on Kafka metrics to detect issues early
+5. **Security**: Use SASL authentication in production environments
+
+## Troubleshooting
+
+### Connection Issues
+- Verify Kafka brokers are reachable from the TensorZero gateway
+- Check firewall rules and network connectivity
+- Ensure broker addresses are correctly formatted (host:port)
+
+### Missing Messages
+- Check if topics exist (auto-creation may be disabled)
+- Verify the topic prefix configuration
+- Check Kafka logs for any errors
+
+### Performance Issues
+- Adjust batch settings (batch_size, linger_ms)
+- Consider using compression
+- Monitor Kafka broker performance

--- a/examples/kafka-config/README.md
+++ b/examples/kafka-config/README.md
@@ -1,0 +1,120 @@
+# Kafka Integration Example
+
+This example demonstrates how to configure TensorZero to send inference data to Apache Kafka.
+
+## Prerequisites
+
+1. A running Kafka instance (see below for Docker setup)
+2. TensorZero gateway with Kafka support
+3. OpenAI API key (or another model provider)
+
+## Running Kafka
+
+Start Kafka using Docker:
+
+```bash
+docker run -d --name kafka -p 9092:9092 \
+  -e KAFKA_NODE_ID=1 \
+  -e KAFKA_PROCESS_ROLES=broker,controller \
+  -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093 \
+  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 \
+  -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
+  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT \
+  -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:9093 \
+  -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1 \
+  -e KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1 \
+  -e KAFKA_LOG_DIRS=/var/lib/kafka/data \
+  -e KAFKA_CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk \
+  apache/kafka:3.7.0
+```
+
+## Running the Example
+
+1. Set up environment variables:
+   ```bash
+   export OPENAI_API_KEY="your-api-key"
+   export TENSORZERO_CLICKHOUSE_URL="http://user:password@localhost:8123/tensorzero"
+   ```
+
+2. Start the TensorZero gateway:
+   ```bash
+   cd examples/kafka-config
+   tensorzero --config tensorzero.toml
+   ```
+
+3. Make an inference request:
+   ```bash
+   curl -X POST http://localhost:3000/inference \
+     -H "Content-Type: application/json" \
+     -d '{
+       "function_name": "example_chat",
+       "input": {
+         "messages": [
+           {"role": "user", "content": "Hello, how are you?"}
+         ]
+       }
+     }'
+   ```
+
+4. Send feedback (this will only go to ClickHouse, not Kafka):
+   ```bash
+   curl -X POST http://localhost:3000/feedback \
+     -H "Content-Type: application/json" \
+     -d '{
+       "inference_id": "<inference-id-from-above>",
+       "metric_name": "accuracy",
+       "value": 0.95
+     }'
+   ```
+
+## Viewing Kafka Messages
+
+You can consume messages from Kafka to verify they're being sent:
+
+```bash
+# List topics
+docker exec kafka kafka-topics --bootstrap-server localhost:9092 --list
+
+# Consume chat inference messages
+docker exec kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 \
+  --topic tensorzero_chat_inference \
+  --from-beginning
+
+# Consume model inference messages
+docker exec kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 \
+  --topic tensorzero_model_inference \
+  --from-beginning
+```
+
+## Configuration Options
+
+The `tensorzero.toml` file demonstrates various Kafka configuration options:
+
+- **Basic settings**: broker addresses, topic prefix
+- **Performance tuning**: compression, batching
+- **Security**: SASL authentication (commented out)
+
+## Monitoring
+
+Check the metrics endpoint to see Kafka operation statistics:
+
+```bash
+curl http://localhost:3001/metrics | grep kafka
+```
+
+You should see metrics like:
+- `kafka_writes_success`
+- `kafka_writes_failed`
+- `kafka_write_duration_ms`
+
+## Troubleshooting
+
+If messages aren't appearing in Kafka:
+
+1. Check the gateway logs for Kafka connection errors
+2. Verify Kafka is running: `docker ps`
+3. Check if async_writes is enabled in the config
+4. Ensure the ClickHouse URL is set (observability must be enabled)

--- a/examples/kafka-config/tensorzero.toml
+++ b/examples/kafka-config/tensorzero.toml
@@ -1,0 +1,70 @@
+# Example TensorZero configuration with Kafka integration
+
+[gateway]
+# Other gateway settings...
+
+[gateway.observability]
+# Enable observability features
+enabled = true
+# Use async writes for better performance
+async_writes = true
+
+# Kafka configuration (for inference data only, feedback goes to ClickHouse only)
+[gateway.observability.kafka]
+# Enable Kafka integration
+enabled = true
+# Kafka broker addresses (comma-separated for multiple brokers)
+brokers = "localhost:9092"
+# Topic prefix for all Kafka topics
+topic_prefix = "tensorzero"
+
+# Optional: Compression settings
+compression_type = "lz4"  # Options: none, gzip, snappy, lz4, zstd
+
+# Optional: Batching settings for better throughput
+batch_size = 1000        # Maximum messages per batch
+linger_ms = 10          # Time to wait for batching (milliseconds)
+
+# Optional: Request timeout
+request_timeout_ms = 5000
+
+# Optional: SASL authentication (uncomment if needed)
+# [gateway.observability.kafka.sasl]
+# mechanism = "PLAIN"  # or "SCRAM-SHA-256", "SCRAM-SHA-512"
+# username = "your-username"
+# password = "your-password"
+
+# Functions configuration
+[functions.example_chat]
+type = "chat"
+
+[functions.example_chat.variants.main]
+type = "chat_completion"
+model = "gpt-3.5-turbo"
+
+[functions.example_json]
+type = "json"
+output_schema = { type = "object", properties = { answer = { type = "string" } } }
+
+[functions.example_json.variants.main]
+type = "chat_completion"
+model = "gpt-3.5-turbo"
+
+# Metrics configuration
+[metrics.accuracy]
+type = "float"
+level = "inference"
+optimize = "max"
+
+[metrics.user_satisfaction]
+type = "boolean"
+level = "episode"
+optimize = "max"
+
+# Model provider configuration
+[models.gpt-3.5-turbo]
+routing = ["openai"]
+
+[model_providers.openai]
+type = "openai"
+# API key should be set via environment variable: OPENAI_API_KEY

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -108,6 +108,7 @@ tower-http = { workspace = true }
 tower-layer = "0.3.3"
 pyo3 = { workspace = true, optional = true }
 google-cloud-auth = "0.20.0"
+redis = { version = "0.31.0", features = ["tokio-comp"] }
 
 
 [dev-dependencies]

--- a/tensorzero-internal/Cargo.toml
+++ b/tensorzero-internal/Cargo.toml
@@ -62,6 +62,7 @@ minijinja = { version = "2.10.2", features = [
 ] }
 object_store = { workspace = true }
 rand = { workspace = true }
+rdkafka = { version = "0.36", features = ["tokio", "ssl", "sasl"] }
 reqwest = { workspace = true }
 reqwest-eventsource = { workspace = true }
 secrecy = { workspace = true }

--- a/tensorzero-internal/src/auth.rs
+++ b/tensorzero-internal/src/auth.rs
@@ -1,0 +1,98 @@
+use serde_json::Value;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{Response, IntoResponse};
+use axum::extract::{State, Request};
+use axum::body::{to_bytes, Body};
+use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+
+pub type APIConfig = HashMap<String, String>;
+
+#[derive(Clone)]
+pub struct Auth {
+    api_keys: Arc<RwLock<HashMap<String, APIConfig>>>
+}
+
+impl Auth {
+    pub fn new(api_keys: HashMap<String, APIConfig>) -> Self {
+        Self { api_keys: Arc::new(RwLock::new(api_keys)) }
+    }
+
+    pub fn update_api_keys(&self, api_key: &str, api_config: APIConfig) {
+        let mut api_keys = self.api_keys.write().unwrap();
+        api_keys.insert(api_key.to_string(), api_config);
+    }
+
+    pub fn delete_api_key(&self, api_key: &str) {
+        let mut api_keys = self.api_keys.write().unwrap();
+        api_keys.remove(api_key);
+    }
+
+    pub fn validate_api_key(&self, api_key: &str) -> Result<APIConfig, StatusCode> {
+        let api_keys = self.api_keys.read().unwrap();
+        if let Some(api_config) = api_keys.get(api_key) {
+            return Ok(api_config.clone());
+        }
+        Err(StatusCode::UNAUTHORIZED)
+    }
+    
+}
+
+pub async fn require_api_key(
+    State(auth): State<Auth>,
+    request: Request,
+    next: Next,
+) -> Result<Response, Response> {
+    let (parts, body) = request.into_parts();
+    let bytes = to_bytes(body, 1024 * 1024).await.unwrap_or_default();
+
+    let key = parts
+        .headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+    
+    let key = match key {
+        Some(key) => {
+            // Strip "Bearer " prefix if present (case-insensitive)
+            let key = key.trim();
+            key.strip_prefix("Bearer ").unwrap_or(key)
+        }
+        None => return Err((StatusCode::UNAUTHORIZED, "Missing authorization header").into_response()),
+    };
+
+    let api_config = auth.validate_api_key(key);
+    if api_config.is_err() {
+        return Err((StatusCode::UNAUTHORIZED, "Invalid API key").into_response());
+    }
+
+    // Parse the JSON body and replace the "model" field with the value from api_config if present
+    let mut val: Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => return Err((StatusCode::UNAUTHORIZED, "Invalid request body").into_response()),
+    };
+
+    let model = match val.get("model").and_then(|v| v.as_str()) {
+        Some(m) => m,
+        None => return Err((StatusCode::UNAUTHORIZED, "Missing model name in request body").into_response()),
+    };
+
+    let api_config = api_config.unwrap();
+    let model_value = match api_config.get(model) {
+        Some(v) => v,
+        None => return Err((StatusCode::UNAUTHORIZED, "API key does not have access to this model").into_response()),
+    };
+
+    // Replace the "model" field in the request body with the value from api_config
+    val["model"] = format!("tensorzero::model_name::{}", model_value.clone()).into();
+
+    // Re-serialize the modified JSON body for the downstream handler
+    let bytes = match serde_json::to_vec(&val) {
+        Ok(b) => b,
+        Err(_) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Failed to serialize modified request body").into_response()),
+    };
+
+    let request = Request::from_parts(parts, Body::from(bytes));
+
+    Ok(next.run(request).await)
+}

--- a/tensorzero-internal/src/auth.rs
+++ b/tensorzero-internal/src/auth.rs
@@ -9,6 +9,15 @@ use std::collections::HashMap;
 
 pub type APIConfig = HashMap<String, String>;
 
+// Common error response helper
+fn auth_error_response(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let body = serde_json::json!({
+        "type": error_type,
+        "error": message
+    });
+    (status, axum::Json(body)).into_response()
+}
+
 #[derive(Clone)]
 pub struct Auth {
     api_keys: Arc<RwLock<HashMap<String, APIConfig>>>
@@ -58,29 +67,49 @@ pub async fn require_api_key(
             let key = key.trim();
             key.strip_prefix("Bearer ").unwrap_or(key)
         }
-        None => return Err((StatusCode::UNAUTHORIZED, "Missing authorization header").into_response()),
+        None => return Err(auth_error_response(
+            StatusCode::UNAUTHORIZED, 
+            "missing_authorization", 
+            "Missing authorization header"
+        )),
     };
 
     let api_config = auth.validate_api_key(key);
     if api_config.is_err() {
-        return Err((StatusCode::UNAUTHORIZED, "Invalid API key").into_response());
+        return Err(auth_error_response(
+            StatusCode::UNAUTHORIZED, 
+            "invalid_api_key", 
+            "Invalid API key"
+        ));
     }
 
     // Parse the JSON body and replace the "model" field with the value from api_config if present
     let mut val: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
-        Err(_) => return Err((StatusCode::UNAUTHORIZED, "Invalid request body").into_response()),
+        Err(_) => return Err(auth_error_response(
+            StatusCode::BAD_REQUEST, 
+            "invalid_request_body", 
+            "Invalid request body"
+        )),
     };
 
     let model = match val.get("model").and_then(|v| v.as_str()) {
         Some(m) => m,
-        None => return Err((StatusCode::UNAUTHORIZED, "Missing model name in request body").into_response()),
+        None => return Err(auth_error_response(
+            StatusCode::BAD_REQUEST, 
+            "invalid_request_body", 
+            "Missing model name in request body"
+        )),
     };
 
     let api_config = api_config.unwrap();
     let model_value = match api_config.get(model) {
         Some(v) => v,
-        None => return Err((StatusCode::UNAUTHORIZED, "API key does not have access to this model").into_response()),
+        None => return Err(auth_error_response(
+            StatusCode::NOT_FOUND, 
+            "model_not_found", 
+            "Model not found in API key"
+        )),
     };
 
     // Replace the "model" field in the request body with the value from api_config
@@ -89,7 +118,11 @@ pub async fn require_api_key(
     // Re-serialize the modified JSON body for the downstream handler
     let bytes = match serde_json::to_vec(&val) {
         Ok(b) => b,
-        Err(_) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "Failed to serialize modified request body").into_response()),
+        Err(_) => return Err(auth_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR, 
+            "serialization_error", 
+            "Failed to serialize modified request body"
+        )),
     };
 
     let request = Request::from_parts(parts, Body::from(bytes));

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -28,6 +28,7 @@ use crate::variant::dicl::UninitializedDiclConfig;
 use crate::variant::mixture_of_n::UninitializedMixtureOfNConfig;
 use crate::variant::{Variant, VariantConfig};
 use std::error::Error as StdError;
+use crate::auth::APIConfig;
 
 tokio::task_local! {
     /// When set, we skip performing credential validation in model providers
@@ -55,6 +56,7 @@ pub struct Config<'c> {
     pub templates: TemplateConfig<'c>,
     pub object_store_info: Option<ObjectStoreInfo>,
     pub provider_types: ProviderTypesConfig,
+    pub api_keys: HashMap<String, APIConfig>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -405,6 +407,7 @@ impl<'c> Config<'c> {
             templates,
             object_store_info,
             provider_types: uninitialized_config.provider_types,
+            api_keys: uninitialized_config.api_keys,
         };
 
         // Initialize the templates
@@ -674,6 +677,8 @@ struct UninitializedConfig {
     pub evaluations: HashMap<String, UninitializedEvaluationConfig>, // evaluation name => evaluation
     #[serde(default)]
     pub provider_types: ProviderTypesConfig, // global configuration for all model providers of a particular type
+    #[serde(default)]
+    pub api_keys: HashMap<String, APIConfig>,
     pub object_storage: Option<StorageKind>,
 }
 

--- a/tensorzero-internal/src/config_parser.rs
+++ b/tensorzero-internal/src/config_parser.rs
@@ -238,6 +238,7 @@ pub struct ObservabilityConfig {
     pub enabled: Option<bool>,
     #[serde(default)]
     pub async_writes: bool,
+    pub kafka: Option<crate::kafka::KafkaConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq)]

--- a/tensorzero-internal/src/endpoints/batch_inference.rs
+++ b/tensorzero-internal/src/endpoints/batch_inference.rs
@@ -211,9 +211,9 @@ pub async fn start_batch_inference_handler(
         credentials: &params.credentials,
         cache_options: &cache_options,
     };
-
+    let models = config.models.read().await;
     let inference_models = InferenceModels {
-        models: &config.models,
+        models: &*models,
         embedding_models: &config.embedding_models,
     };
     let inference_params: Vec<InferenceParams> =
@@ -347,8 +347,9 @@ pub async fn poll_batch_inference_handler(
         BatchStatus::Pending => {
             // For now, we don't support dynamic API keys for batch inference
             let credentials = InferenceCredentials::default();
+            let models = config.models.read().await;
             let response =
-                poll_batch_inference(&batch_request, http_client, &config.models, &credentials)
+                poll_batch_inference(&batch_request, http_client, &*models, &credentials)
                     .await?;
             let response = write_poll_batch_inference(
                 &clickhouse_connection_info,

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -383,6 +383,15 @@ pub enum ErrorDetails {
         path: String,
         method: String,
     },
+    KafkaConnection {
+        message: String,
+    },
+    KafkaProducer {
+        message: String,
+    },
+    KafkaSerialization {
+        message: String,
+    },
 }
 
 impl ErrorDetails {
@@ -472,6 +481,9 @@ impl ErrorDetails {
             ErrorDetails::UnsupportedVariantForStreamingInference { .. } => tracing::Level::WARN,
             ErrorDetails::UuidInFuture { .. } => tracing::Level::WARN,
             ErrorDetails::RouteNotFound { .. } => tracing::Level::WARN,
+            ErrorDetails::KafkaConnection { .. } => tracing::Level::ERROR,
+            ErrorDetails::KafkaProducer { .. } => tracing::Level::ERROR,
+            ErrorDetails::KafkaSerialization { .. } => tracing::Level::ERROR,
         }
     }
 
@@ -569,6 +581,9 @@ impl ErrorDetails {
             }
             ErrorDetails::UuidInFuture { .. } => StatusCode::BAD_REQUEST,
             ErrorDetails::RouteNotFound { .. } => StatusCode::NOT_FOUND,
+            ErrorDetails::KafkaConnection { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::KafkaProducer { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::KafkaSerialization { .. } => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 
@@ -969,6 +984,15 @@ impl std::fmt::Display for ErrorDetails {
             }
             ErrorDetails::RouteNotFound { path, method } => {
                 write!(f, "Route not found: {method} {path}")
+            }
+            ErrorDetails::KafkaConnection { message } => {
+                write!(f, "Error connecting to Kafka: {message}")
+            }
+            ErrorDetails::KafkaProducer { message } => {
+                write!(f, "Error with Kafka producer: {message}")
+            }
+            ErrorDetails::KafkaSerialization { message } => {
+                write!(f, "Error serializing message for Kafka: {message}")
             }
         }
     }

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -52,9 +52,17 @@ impl AppStateData {
             clickhouse_connection_info,
         })
     }
-    pub async fn update_model_table(&self, new_models: ModelTable) {
+    pub async fn update_model_table(&self, mut new_models: ModelTable) {
         let mut models = self.config.models.write().await;
-        *models = new_models;
+        
+        for (name, config) in std::mem::take(&mut *new_models).into_iter() {
+            models.insert(name, config);
+        }
+    }
+
+    pub async fn remove_model_table(&self, model_name: &str) {
+        let mut models = self.config.models.write().await;
+        models.remove(model_name);
     }
 }
 

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -14,6 +14,7 @@ use tracing::instrument;
 use crate::clickhouse::migration_manager;
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::config_parser::Config;
+use crate::kafka::KafkaConnectionInfo;
 use crate::model::ModelTable;
 use crate::endpoints;
 use crate::error::{Error, ErrorDetails};
@@ -23,6 +24,7 @@ pub struct AppStateData {
     pub config: Arc<Config<'static>>,
     pub http_client: Client,
     pub clickhouse_connection_info: ClickHouseConnectionInfo,
+    pub kafka_connection_info: KafkaConnectionInfo,
 }
 pub type AppState = axum::extract::State<AppStateData>;
 
@@ -44,12 +46,14 @@ impl AppStateData {
         clickhouse_url: Option<String>,
     ) -> Result<Self, Error> {
         let clickhouse_connection_info = setup_clickhouse(&config, clickhouse_url, false).await?;
+        let kafka_connection_info = setup_kafka(&config).await?;
         let http_client = setup_http_client()?;
 
         Ok(Self {
             config,
             http_client,
             clickhouse_connection_info,
+            kafka_connection_info,
         })
     }
     pub async fn update_model_table(&self, mut new_models: ModelTable) {
@@ -107,6 +111,31 @@ pub async fn setup_clickhouse(
         migration_manager::run(&clickhouse_connection_info).await?;
     }
     Ok(clickhouse_connection_info)
+}
+
+pub async fn setup_kafka(config: &Config<'static>) -> Result<KafkaConnectionInfo, Error> {
+    let kafka_config = config.gateway.observability.kafka.as_ref();
+    
+    match kafka_config {
+        Some(kafka_conf) if kafka_conf.enabled => {
+            tracing::info!("Initializing Kafka producer with brokers: {}", kafka_conf.brokers);
+            match KafkaConnectionInfo::new(Some(kafka_conf)) {
+                Ok(conn) => {
+                    tracing::info!("Successfully initialized Kafka producer");
+                    Ok(conn)
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize Kafka producer: {}", e);
+                    // Return error since Kafka is explicitly enabled
+                    Err(e)
+                }
+            }
+        }
+        _ => {
+            tracing::info!("Kafka integration is disabled");
+            Ok(KafkaConnectionInfo::Disabled)
+        }
+    }
 }
 
 /// Custom Axum extractor that validates the JSON body and deserializes it into a custom type

--- a/tensorzero-internal/src/gateway_util.rs
+++ b/tensorzero-internal/src/gateway_util.rs
@@ -17,8 +17,6 @@ use crate::config_parser::Config;
 use crate::model::ModelTable;
 use crate::endpoints;
 use crate::error::{Error, ErrorDetails};
-use crate::redis_client::RedisClient;
-
 /// State for the API
 #[derive(Clone)]
 pub struct AppStateData {
@@ -38,7 +36,6 @@ impl AppStateData {
                 })
             });
         let state = Self::new_with_clickhouse(config, clickhouse_url).await?;
-        state.setup_redis_client().await?;
         Ok(state)
     }
 
@@ -58,28 +55,6 @@ impl AppStateData {
     pub async fn update_model_table(&self, new_models: ModelTable) {
         let mut models = self.config.models.write().await;
         *models = new_models;
-    }
-
-    async fn setup_redis_client(&self) -> Result<Option<RedisClient>, Error> {
-        let redis_url = match std::env::var("TENSORZERO_REDIS_URL") {
-            Ok(url) => url,
-            Err(_) => {
-                tracing::warn!("TENSORZERO_REDIS_URL is not set, redis client will not be used");
-                return Ok(None);
-            }
-        };
-        if redis_url.is_empty() {
-            tracing::warn!("TENSORZERO_REDIS_URL is set to an empty string, redis client will not be used");
-            return Ok(None);
-        }
-        
-        let updater = RedisClient::new(&redis_url, self.clone());
-        updater.start().await.map_err(|e| {
-            tracing::error!("Failed to start redis model updater: {e}");
-            e
-        })?;
-
-        Ok(None)
     }
 }
 

--- a/tensorzero-internal/src/kafka/mod.rs
+++ b/tensorzero-internal/src/kafka/mod.rs
@@ -1,0 +1,327 @@
+use crate::error::{Error, ErrorDetails};
+use metrics::{counter, histogram};
+use rdkafka::config::ClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::Timeout;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{error, warn};
+
+#[derive(Clone, Debug)]
+pub enum KafkaConnectionInfo {
+    Disabled,
+    #[cfg(any(test, feature = "e2e_tests"))]
+    Mock(MockKafkaConnectionInfo),
+    Production(Arc<KafkaProducerInfo>),
+}
+
+#[derive(Debug)]
+pub struct KafkaProducerInfo {
+    pub producer: FutureProducer,
+    pub topic_prefix: String,
+}
+
+#[cfg(any(test, feature = "e2e_tests"))]
+#[derive(Clone, Debug)]
+pub struct MockKafkaConnectionInfo {
+    pub messages: Arc<tokio::sync::Mutex<Vec<(String, String, String)>>>, // (topic, key, value)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KafkaConfig {
+    pub enabled: bool,
+    pub brokers: String,
+    pub topic_prefix: String,
+    #[serde(default)]
+    pub compression_type: Option<String>,
+    #[serde(default)]
+    pub batch_size: Option<i32>,
+    #[serde(default)]
+    pub linger_ms: Option<i32>,
+    #[serde(default)]
+    pub request_timeout_ms: Option<i32>,
+    #[serde(default)]
+    pub sasl: Option<KafkaSaslConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KafkaSaslConfig {
+    pub mechanism: String,
+    pub username: String,
+    pub password: String,
+}
+
+impl KafkaConnectionInfo {
+    pub fn new(config: Option<&KafkaConfig>) -> Result<Self, Error> {
+        match config {
+            None => Ok(KafkaConnectionInfo::Disabled),
+            Some(config) if !config.enabled => Ok(KafkaConnectionInfo::Disabled),
+            Some(config) => {
+                let mut client_config = ClientConfig::new();
+                
+                // Basic configuration
+                client_config
+                    .set("bootstrap.servers", &config.brokers)
+                    .set("message.timeout.ms", "5000")
+                    .set("enable.idempotence", "true");
+                
+                // Optional compression
+                if let Some(compression) = &config.compression_type {
+                    client_config.set("compression.type", compression);
+                }
+                
+                // Optional batch settings
+                if let Some(batch_size) = config.batch_size {
+                    client_config.set("batch.size", batch_size.to_string());
+                }
+                
+                if let Some(linger_ms) = config.linger_ms {
+                    client_config.set("linger.ms", linger_ms.to_string());
+                }
+                
+                if let Some(timeout_ms) = config.request_timeout_ms {
+                    client_config.set("request.timeout.ms", timeout_ms.to_string());
+                }
+                
+                // SASL configuration
+                if let Some(sasl) = &config.sasl {
+                    client_config
+                        .set("security.protocol", "SASL_SSL")
+                        .set("sasl.mechanism", &sasl.mechanism)
+                        .set("sasl.username", &sasl.username)
+                        .set("sasl.password", &sasl.password);
+                }
+                
+                let producer: FutureProducer = client_config.create().map_err(|e| {
+                    counter!("kafka_connection_errors").increment(1);
+                    ErrorDetails::KafkaConnection {
+                        message: format!("Failed to create Kafka producer: {}", e),
+                    }
+                })?;
+                
+                counter!("kafka_connections_established").increment(1);
+                Ok(KafkaConnectionInfo::Production(Arc::new(
+                    KafkaProducerInfo {
+                        producer,
+                        topic_prefix: config.topic_prefix.clone(),
+                    },
+                )))
+            }
+        }
+    }
+    
+    pub async fn write<T: Serialize>(
+        &self,
+        payloads: &[T],
+        data_type: &str,
+    ) -> Result<(), Error> {
+        match self {
+            KafkaConnectionInfo::Disabled => Ok(()),
+            #[cfg(any(test, feature = "e2e_tests"))]
+            KafkaConnectionInfo::Mock(mock) => {
+                let mut messages = mock.messages.lock().await;
+                for payload in payloads {
+                    let value = serde_json::to_string(payload).map_err(|e| {
+                        ErrorDetails::KafkaSerialization {
+                            message: format!("Failed to serialize payload: {}", e),
+                        }
+                    })?;
+                    
+                    // For mock, we'll use a simple key extraction
+                    let key = extract_key_from_payload(&value);
+                    let topic = format!("{}_{}", "test", data_type);
+                    
+                    messages.push((topic, key, value));
+                }
+                Ok(())
+            }
+            KafkaConnectionInfo::Production(producer_info) => {
+                let topic = format!("{}_{}", producer_info.topic_prefix, data_type);
+                let labels = &[("topic", topic.clone()), ("data_type", data_type.to_string())];
+                
+                for payload in payloads {
+                    let start_time = std::time::Instant::now();
+                    
+                    let value = serde_json::to_string(payload).map_err(|e| {
+                        counter!("kafka_serialization_errors", labels).increment(1);
+                        ErrorDetails::KafkaSerialization {
+                            message: format!("Failed to serialize payload: {}", e),
+                        }
+                    })?;
+                    
+                    let key = extract_key_from_payload(&value);
+                    
+                    let record = FutureRecord::to(&topic)
+                        .key(&key)
+                        .payload(&value);
+                    
+                    // Send with a timeout
+                    let delivery_result = producer_info
+                        .producer
+                        .send(record, Timeout::After(Duration::from_secs(5)))
+                        .await;
+                    
+                    match delivery_result {
+                        Ok((partition, offset)) => {
+                            let duration = start_time.elapsed();
+                            histogram!("kafka_write_duration_ms", labels)
+                                .record(duration.as_millis() as f64);
+                            counter!("kafka_writes_success", labels).increment(1);
+                            tracing::debug!(
+                                "Successfully sent message to Kafka topic {} partition {} offset {}",
+                                topic, partition, offset
+                            );
+                        }
+                        Err((e, _)) => {
+                            counter!("kafka_writes_failed", labels).increment(1);
+                            error!("Failed to send message to Kafka: {:?}", e);
+                            return Err(ErrorDetails::KafkaProducer {
+                                message: format!("Failed to send message to Kafka: {:?}", e),
+                            }
+                            .into());
+                        }
+                    }
+                }
+                
+                Ok(())
+            }
+        }
+    }
+}
+
+// Helper function to extract ID from JSON payload for use as Kafka key
+fn extract_key_from_payload(json_str: &str) -> String {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) {
+        // Try to find an ID field
+        if let Some(id) = value.get("id").and_then(|v| v.as_str()) {
+            return id.to_string();
+        }
+        if let Some(inference_id) = value.get("inference_id").and_then(|v| v.as_str()) {
+            return inference_id.to_string();
+        }
+        if let Some(episode_id) = value.get("episode_id").and_then(|v| v.as_str()) {
+            return episode_id.to_string();
+        }
+        if let Some(target_id) = value.get("target_id").and_then(|v| v.as_str()) {
+            return target_id.to_string();
+        }
+    }
+    
+    // Fallback to empty key
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    
+    #[test]
+    fn test_extract_key_from_payload() {
+        let payload1 = json!({"id": "test-id-123", "data": "value"});
+        assert_eq!(
+            extract_key_from_payload(&payload1.to_string()),
+            "test-id-123"
+        );
+        
+        let payload2 = json!({"inference_id": "inf-456", "data": "value"});
+        assert_eq!(
+            extract_key_from_payload(&payload2.to_string()),
+            "inf-456"
+        );
+        
+        let payload3 = json!({"episode_id": "ep-789", "data": "value"});
+        assert_eq!(extract_key_from_payload(&payload3.to_string()), "ep-789");
+        
+        let payload4 = json!({"target_id": "tgt-000", "data": "value"});
+        assert_eq!(extract_key_from_payload(&payload4.to_string()), "tgt-000");
+        
+        let payload5 = json!({"data": "value"});
+        assert_eq!(extract_key_from_payload(&payload5.to_string()), "");
+    }
+    
+    #[tokio::test]
+    async fn test_kafka_connection_disabled() {
+        let conn = KafkaConnectionInfo::Disabled;
+        let payload = json!({"test": "data"});
+        
+        // Should succeed without doing anything
+        assert!(conn.write(&[payload], "test_topic").await.is_ok());
+    }
+    
+    #[cfg(any(test, feature = "e2e_tests"))]
+    #[tokio::test]
+    async fn test_kafka_connection_mock() {
+        let mock = MockKafkaConnectionInfo {
+            messages: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        };
+        let conn = KafkaConnectionInfo::Mock(mock.clone());
+        
+        let payload = json!({"id": "test-123", "data": "test-value"});
+        
+        conn.write(&[payload], "test_data").await.unwrap();
+        
+        let messages = mock.messages.lock().await;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].0, "test_test_data");
+        assert_eq!(messages[0].1, "test-123");
+        assert!(messages[0].2.contains("test-value"));
+    }
+    
+    #[test]
+    fn test_kafka_config_creation() {
+        // Test disabled config
+        let config = None;
+        let conn = KafkaConnectionInfo::new(config).unwrap();
+        assert!(matches!(conn, KafkaConnectionInfo::Disabled));
+        
+        // Test explicitly disabled config
+        let config = Some(&KafkaConfig {
+            enabled: false,
+            brokers: "localhost:9092".to_string(),
+            topic_prefix: "test".to_string(),
+            compression_type: None,
+            batch_size: None,
+            linger_ms: None,
+            request_timeout_ms: None,
+            sasl: None,
+        });
+        let conn = KafkaConnectionInfo::new(config).unwrap();
+        assert!(matches!(conn, KafkaConnectionInfo::Disabled));
+    }
+    
+    #[cfg(any(test, feature = "e2e_tests"))]
+    #[tokio::test]
+    async fn test_kafka_mock_multiple_writes() {
+        let mock = MockKafkaConnectionInfo {
+            messages: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        };
+        let conn = KafkaConnectionInfo::Mock(mock.clone());
+        
+        // Test multiple payloads at once
+        let payloads = vec![
+            json!({"id": "1", "type": "inference"}),
+            json!({"inference_id": "2", "type": "model"}),
+            json!({"episode_id": "3", "type": "chat"}),
+        ];
+        
+        conn.write(&payloads, "bulk_test").await.unwrap();
+        
+        let messages = mock.messages.lock().await;
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].0, "test_bulk_test");
+        assert_eq!(messages[0].1, "1");
+        assert_eq!(messages[1].1, "2");
+        assert_eq!(messages[2].1, "3");
+    }
+    
+    #[test]
+    fn test_extract_key_from_invalid_json() {
+        let invalid_json = "not a json";
+        assert_eq!(extract_key_from_payload(invalid_json), "");
+        
+        let json_without_id = json!({"data": "value", "other": "field"});
+        assert_eq!(extract_key_from_payload(&json_without_id.to_string()), "");
+    }
+}

--- a/tensorzero-internal/src/lib.rs
+++ b/tensorzero-internal/src/lib.rs
@@ -21,6 +21,7 @@ mod testing;
 pub mod tool; // types and methods for working with TensorZero tools
 mod uuid_util; // utilities for working with UUIDs
 pub mod variant; // types and methods for working with TensorZero variants
+pub mod redis_client; // redis client
 
 pub mod built_info {
     #![expect(clippy::allow_attributes)]

--- a/tensorzero-internal/src/lib.rs
+++ b/tensorzero-internal/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tool; // types and methods for working with TensorZero tools
 mod uuid_util; // utilities for working with UUIDs
 pub mod variant; // types and methods for working with TensorZero variants
 pub mod redis_client; // redis client
+pub mod auth; // authentication
 
 pub mod built_info {
     #![expect(clippy::allow_attributes)]

--- a/tensorzero-internal/src/lib.rs
+++ b/tensorzero-internal/src/lib.rs
@@ -13,6 +13,7 @@ pub mod function; // types and methods for working with TensorZero functions
 pub mod gateway_util; // utilities for gateway
 pub mod inference; // model inference
 pub mod jsonschema_util; // utilities for working with JSON schemas
+pub mod kafka; // Kafka integration
 mod minijinja_util; // utilities for working with MiniJinja templates
 pub mod model; // types and methods for working with TensorZero-supported models
 pub mod model_table;

--- a/tensorzero-internal/src/model_table.rs
+++ b/tensorzero-internal/src/model_table.rs
@@ -68,6 +68,12 @@ impl<T: ShorthandModelConfig> std::ops::Deref for BaseModelTable<T> {
     }
 }
 
+impl<T: ShorthandModelConfig> std::ops::DerefMut for BaseModelTable<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 /// This is `Cow` without the `T: Clone` bound.
 /// Useful when we want a `Cow`, but don't want to (or can't) implement `Clone`
 #[derive(Debug)]

--- a/tensorzero-internal/src/redis_client.rs
+++ b/tensorzero-internal/src/redis_client.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use tracing::instrument;
+
+use crate::error::{Error, ErrorDetails};
+use crate::model::{ModelTable, UninitializedModelConfig};
+use crate::config_parser::ProviderTypesConfig;
+use crate::gateway_util::AppStateData;
+
+pub struct RedisClient {
+    redis_url: String,
+    app_state: AppStateData
+}
+
+impl RedisClient {
+    pub fn new(url: &str, app_state: AppStateData) -> Self {
+        Self { redis_url: url.to_string(), app_state }
+    }
+
+    async fn parse_models(json: &str, provider_types: &ProviderTypesConfig) -> Result<ModelTable, Error> {
+        let raw: HashMap<String, UninitializedModelConfig> =
+            serde_json::from_str(json).map_err(|e| {
+                Error::new(ErrorDetails::Config {
+                    message: format!("Failed to parse models from redis: {e}"),
+                })
+            })?;
+        
+        let models = raw
+            .into_iter()
+            .map(|(name, config)| {
+                config
+                    .load(&name, provider_types)
+                    .map(|c| (Arc::<str>::from(name), c))
+            })
+            .collect::<Result<HashMap<_, _>, Error>>()?;
+        
+        models.try_into().map_err(|e| {
+            Error::new(ErrorDetails::Config {
+                message: format!("Failed to load models: {e}"),
+            })
+        })
+    }
+
+    #[instrument(skip(self))]
+    pub async fn start(self) -> Result<(), Error> {
+        let client = redis::Client::open(self.redis_url).map_err(|e| {
+            Error::new(ErrorDetails::Config {
+                message: format!("Failed to connect to Redis: {e}"),
+            })
+        })?;
+
+        // Get a connection for pubsub
+        let mut pubsub_conn = client
+            .get_async_pubsub()
+            .await
+            .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to connect to redis: {e}") }))?;
+        // let mut pubsub = pubsub_conn.into_pubsub();
+
+        pubsub_conn
+            .subscribe("model_table_updates")
+            .await
+            .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to subscribe to redis: {e}") }))?;
+
+        let app_state = self.app_state.clone();
+
+        tokio::spawn(async move {
+            let mut stream = pubsub_conn.on_message();
+            while let Some(msg) = stream.next().await {
+                let payload: String = match msg.get_payload() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        tracing::error!("Failed to decode redis message: {e}");
+                        continue;
+                    }
+                };
+
+                match Self::parse_models(&payload, &app_state.config.provider_types).await {
+                    Ok(models) => app_state.update_model_table(models).await,
+                    Err(e) => tracing::error!("Failed to parse models from redis: {e}")
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+}

--- a/tensorzero-internal/src/redis_client.rs
+++ b/tensorzero-internal/src/redis_client.rs
@@ -2,21 +2,33 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::StreamExt;
+use redis::AsyncCommands;
 use tracing::instrument;
 
 use crate::error::{Error, ErrorDetails};
 use crate::model::{ModelTable, UninitializedModelConfig};
 use crate::config_parser::ProviderTypesConfig;
 use crate::gateway_util::AppStateData;
+use crate::auth::{Auth, APIConfig};
 
 pub struct RedisClient {
     redis_url: String,
-    app_state: AppStateData
+    app_state: AppStateData,
+    auth: Option<Auth>,
 }
 
 impl RedisClient {
     pub fn new(url: &str, app_state: AppStateData) -> Self {
-        Self { redis_url: url.to_string(), app_state }
+        Self { 
+            redis_url: url.to_string(), 
+            app_state,
+            auth: None,
+        }
+    }
+
+    pub fn with_auth(mut self, auth: Auth) -> Self {
+        self.auth = Some(auth);
+        self
     }
 
     async fn parse_models(json: &str, provider_types: &ProviderTypesConfig) -> Result<ModelTable, Error> {
@@ -43,6 +55,14 @@ impl RedisClient {
         })
     }
 
+    async fn parse_api_keys(json: &str) -> Result<HashMap<String, APIConfig>, Error> {
+        serde_json::from_str(json).map_err(|e| {
+            Error::new(ErrorDetails::Config {
+                message: format!("Failed to parse API keys from redis: {e}"),
+            })
+        })
+    }
+
     #[instrument(skip(self))]
     pub async fn start(self) -> Result<(), Error> {
         let client = redis::Client::open(self.redis_url).map_err(|e| {
@@ -51,23 +71,68 @@ impl RedisClient {
             })
         })?;
 
+        // Initial fetch: fetch all model_table_* and api_keys_* keys
+        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
+            // Fetch all model_table_* keys
+            if let Ok(model_keys) = conn.keys::<_, Vec<String>>("model_table_*").await {
+                for key in model_keys {
+                    if let Ok(json) = conn.get::<&str, String>(key.as_str()).await {
+                        match Self::parse_models(&json, &self.app_state.config.provider_types).await {
+                            Ok(models) => self.app_state.update_model_table(models).await,
+                            Err(e) => tracing::error!("Failed to parse initial model table from redis (key: {key}): {e}"),
+                        }
+                    }
+                }
+            }
+            // Fetch all api_keys_* keys
+            if let Ok(api_keys_keys) = conn.keys::<_, Vec<String>>("api_keys_*").await {
+                for key in api_keys_keys {
+                    if let Ok(json) = conn.get::<&str, String>(key.as_str()).await {
+                        match Self::parse_api_keys(&json).await {
+                            Ok(keys) => {
+                                if let Some(ref auth) = self.auth {
+                                    for (api_key, config) in keys {
+                                        auth.update_api_keys(&api_key, config);
+                                    }
+                                }
+                            },
+                            Err(e) => tracing::error!("Failed to parse initial api keys from redis (key: {key}): {e}"),
+                        }
+                    }
+                }
+            }
+        }
+
         // Get a connection for pubsub
         let mut pubsub_conn = client
             .get_async_pubsub()
             .await
             .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to connect to redis: {e}") }))?;
-        // let mut pubsub = pubsub_conn.into_pubsub();
 
+        // Subscribe to model updates
         pubsub_conn
             .subscribe("model_table_updates")
             .await
-            .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to subscribe to redis: {e}") }))?;
+            .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to subscribe to model_table_updates: {e}") }))?;
+
+        // Subscribe to API key updates if auth is available
+        if self.auth.is_some() {
+            pubsub_conn
+                .subscribe("api_keys_updates")
+                .await
+                .map_err(|e| Error::new(ErrorDetails::Config { message: format!("Failed to subscribe to api_keys_updates: {e}") }))?;
+        }
 
         let app_state = self.app_state.clone();
+        let auth = self.auth.clone();
 
         tokio::spawn(async move {
             let mut stream = pubsub_conn.on_message();
             while let Some(msg) = stream.next().await {
+                let channel: String = match msg.get_channel_name() {
+                    s => s.to_string()
+                };
+
                 let payload: String = match msg.get_payload() {
                     Ok(p) => p,
                     Err(e) => {
@@ -76,14 +141,36 @@ impl RedisClient {
                     }
                 };
 
-                match Self::parse_models(&payload, &app_state.config.provider_types).await {
-                    Ok(models) => app_state.update_model_table(models).await,
-                    Err(e) => tracing::error!("Failed to parse models from redis: {e}")
+                match channel.as_str() {
+                    "model_table_updates" => {
+                        match Self::parse_models(&payload, &app_state.config.provider_types).await {
+                            Ok(models) => app_state.update_model_table(models).await,
+                            Err(e) => tracing::error!("Failed to parse models from redis: {e}")
+                        }
+                    }
+                    "api_keys_updates" => {
+                        if let Some(ref auth_instance) = auth {
+                            match Self::parse_api_keys(&payload).await {
+                                Ok(api_keys) => {
+                                    // Update all API keys (replace the entire HashMap)
+                                    for (key, config) in api_keys {
+                                        auth_instance.update_api_keys(&key, config);
+                                    }
+                                    tracing::info!("Updated API keys from Redis");
+                                }
+                                Err(e) => tracing::error!("Failed to parse API keys from redis: {e}")
+                            }
+                        } else {
+                            tracing::warn!("Received API keys update but no Auth instance available");
+                        }
+                    }
+                    _ => {
+                        tracing::warn!("Received message from unknown channel: {channel}");
+                    }
                 }
             }
         });
 
         Ok(())
     }
-
 }

--- a/tensorzero-internal/src/testing.rs
+++ b/tensorzero-internal/src/testing.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::clickhouse::ClickHouseConnectionInfo;
 use crate::config_parser::Config;
 use crate::gateway_util::AppStateData;
+use crate::kafka::KafkaConnectionInfo;
 
 pub fn get_unit_test_app_state_data(
     config: Arc<Config<'static>>,
@@ -12,10 +13,12 @@ pub fn get_unit_test_app_state_data(
 ) -> AppStateData {
     let http_client = reqwest::Client::new();
     let clickhouse_connection_info = ClickHouseConnectionInfo::new_mock(clickhouse_healthy);
+    let kafka_connection_info = KafkaConnectionInfo::Disabled;
 
     AppStateData {
         config,
         http_client,
         clickhouse_connection_info,
+        kafka_connection_info,
     }
 }

--- a/tensorzero-internal/tests/e2e/docker-compose.yml
+++ b/tensorzero-internal/tests/e2e/docker-compose.yml
@@ -48,4 +48,27 @@ services:
       - "4317:4317"
       - "4318:4318"
       - "5778:5778"
-      - "9411:9411"
+  
+  kafka:
+    image: apache/kafka:3.7.0
+    ports:
+      - "9092:9092"
+    environment:
+      # Configure Kafka to use KRaft mode (no Zookeeper)
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      KAFKA_CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: kafka-broker-api-versions --bootstrap-server localhost:9092
+      start_period: 30s
+      start_interval: 1s
+      timeout: 5s

--- a/tensorzero-internal/tests/e2e/kafka_integration.rs
+++ b/tensorzero-internal/tests/e2e/kafka_integration.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "e2e_tests")]
+
+use serde_json::json;
+use tensorzero_internal::kafka::{KafkaConfig, KafkaConnectionInfo};
+use uuid::Uuid;
+
+#[tokio::test]
+#[ignore] // This test requires a running Kafka instance
+async fn test_kafka_integration_with_real_broker() {
+    // This test assumes Kafka is running on localhost:9092
+    // You can run it with: docker run -d --name kafka -p 9092:9092 apache/kafka:latest
+    
+    let config = KafkaConfig {
+        enabled: true,
+        brokers: "localhost:9092".to_string(),
+        topic_prefix: "tensorzero_test".to_string(),
+        compression_type: Some("lz4".to_string()),
+        batch_size: Some(1000),
+        linger_ms: Some(10),
+        request_timeout_ms: Some(5000),
+        sasl: None,
+    };
+    
+    let kafka_conn = KafkaConnectionInfo::new(Some(&config)).unwrap();
+    
+    // Test writing inference data
+    let inference_id = Uuid::now_v7();
+    let inference_payload = json!({
+        "id": inference_id,
+        "function_name": "test_function",
+        "variant_name": "test_variant",
+        "episode_id": Uuid::now_v7(),
+        "output": {"content": "test response"},
+        "processing_time_ms": 123
+    });
+    
+    // This should succeed if Kafka is running
+    let result = kafka_conn.write(&[inference_payload], "chat_inference").await;
+    assert!(result.is_ok());
+    
+    // Test batch writes
+    let batch_payloads = vec![
+        json!({"id": Uuid::now_v7(), "data": "batch1"}),
+        json!({"id": Uuid::now_v7(), "data": "batch2"}),
+        json!({"id": Uuid::now_v7(), "data": "batch3"}),
+    ];
+    
+    let result = kafka_conn.write(&batch_payloads, "batch_test").await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_kafka_connection_error_handling() {
+    // Test with invalid broker address
+    let config = KafkaConfig {
+        enabled: true,
+        brokers: "invalid:99999".to_string(),
+        topic_prefix: "test".to_string(),
+        compression_type: None,
+        batch_size: None,
+        linger_ms: None,
+        request_timeout_ms: Some(1000), // Short timeout for test
+        sasl: None,
+    };
+    
+    // This should fail to create the producer
+    let kafka_conn = KafkaConnectionInfo::new(Some(&config));
+    // Note: rdkafka might not fail immediately on creation, so we might need to test writes
+    
+    if let Ok(conn) = kafka_conn {
+        let payload = json!({"id": "test", "data": "test"});
+        let result = conn.write(&[payload], "test_topic").await;
+        // This should fail with a timeout or connection error
+        assert!(result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod docker_compose_tests {
+    use super::*;
+    
+    // This test requires the docker-compose setup from tests/e2e/docker-compose.yml
+    // to be running with a Kafka service added
+    #[tokio::test]
+    #[ignore]
+    async fn test_kafka_with_docker_compose() {
+        // Assuming docker-compose.yml includes:
+        // kafka:
+        //   image: apache/kafka:latest
+        //   ports:
+        //     - "9092:9092"
+        //   environment:
+        //     KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+        //     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+        
+        let config = KafkaConfig {
+            enabled: true,
+            brokers: "localhost:9092".to_string(),
+            topic_prefix: "e2e_test".to_string(),
+            compression_type: Some("snappy".to_string()),
+            batch_size: None,
+            linger_ms: None,
+            request_timeout_ms: None,
+            sasl: None,
+        };
+        
+        let kafka_conn = KafkaConnectionInfo::new(Some(&config)).unwrap();
+        
+        // Test complete inference flow
+        let inference_data = json!({
+            "id": Uuid::now_v7(),
+            "function_name": "chat_completion",
+            "variant_name": "gpt-4",
+            "episode_id": Uuid::now_v7(),
+            "input": {"messages": [{"role": "user", "content": "Hello"}]},
+            "output": {"content": "Hello! How can I help you?"},
+            "model_name": "gpt-4",
+            "model_provider_name": "openai",
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "response_time_ms": 500,
+            "cached": false
+        });
+        
+        let result = kafka_conn.write(&[inference_data], "model_inference").await;
+        assert!(result.is_ok());
+    }
+}

--- a/tensorzero-internal/tests/e2e/tests.rs
+++ b/tensorzero-internal/tests/e2e/tests.rs
@@ -12,6 +12,7 @@ mod feedback;
 mod health;
 mod human_static_evaluation_feedback;
 mod inference;
+mod kafka_integration;
 mod mixture_of_n;
 mod object_storage;
 mod openai_compatible;


### PR DESCRIPTION
## Summary

This PR implements Apache Kafka integration for streaming inference data, as requested in #8. Kafka serves as an optional secondary destination alongside ClickHouse, enabling real-time event streaming for downstream processing.

## Changes

### Core Implementation
- **New Kafka module** (`kafka/mod.rs`): Implements `KafkaConnectionInfo` with production, mock, and disabled modes
- **Configuration extension**: Added `[gateway.observability.kafka]` section to support Kafka settings
- **Non-blocking writes**: Uses `tokio::spawn` to ensure Kafka operations don't block inference requests
- **Smart partitioning**: Extracts IDs from payloads for use as Kafka message keys

### Integration Points
- **Inference endpoint**: Modified `write_inference()` to publish to both ClickHouse and Kafka in parallel
- **Feedback endpoint**: Remains ClickHouse-only (feedback data is not sent to Kafka)

### Kafka Topics
When enabled, inference data is published to:
- `{prefix}_model_inference` - Raw model provider responses
- `{prefix}_chat_inference` - Chat completion results
- `{prefix}_json_inference` - JSON mode results

### Features
- ✅ Compression support (none, gzip, snappy, lz4, zstd)
- ✅ Batching configuration for throughput optimization
- ✅ SASL authentication (PLAIN, SCRAM-SHA-256/512)
- ✅ Comprehensive metrics (connections, writes, failures, latency)
- ✅ Graceful error handling - Kafka failures are logged but don't fail requests

### Testing
- Unit tests for configuration, mock writes, and key extraction
- Integration tests with real Kafka broker
- Added Kafka service to E2E docker-compose.yml
- Mock implementation for testing without Kafka

### Documentation
- Comprehensive guide in `docs/kafka-integration.md`
- Example configuration with detailed comments
- README with setup instructions and troubleshooting

## Configuration Example

```toml
[gateway.observability.kafka]
enabled = true
brokers = "localhost:9092"
topic_prefix = "tensorzero"
compression_type = "lz4"
batch_size = 1000
linger_ms = 10

# Optional SASL authentication
[gateway.observability.kafka.sasl]
mechanism = "PLAIN"
username = "your-username"
password = "your-password"
```

## Testing

1. Unit tests: `cargo test kafka`
2. Integration tests (requires Kafka): `cargo test --features e2e_tests kafka_integration -- --ignored`
3. Manual testing with docker-compose:
   ```bash
   cd tensorzero-internal/tests/e2e
   docker-compose up kafka
   ```

## Performance Impact

- Non-blocking writes ensure no latency impact on inference requests
- Batching and compression minimize network overhead
- Metrics allow monitoring of Kafka operation performance

## Breaking Changes

None. Kafka integration is opt-in and disabled by default.

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>