### PR TITLE
feat: Add image generation support to xAI provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,3 +486,94 @@ cargo test --package tensorzero-internal test_together_image
 # Run integration tests (requires test configuration)
 cargo test --package tensorzero-internal test_openai_compatible_image_generation
 ```
+
+## xAI Provider Image Generation
+
+### Overview
+
+The xAI provider now supports image generation through OpenAI-compatible endpoints, enabling access to xAI's `grok-2-image` model:
+- **grok-2-image** - xAI's high-quality image generation model
+- **Pricing**: $0.07 per image
+- **Rate Limits**: 5 requests/second, up to 10 images per request
+
+### Configuration
+
+```toml
+# Image generation model configuration
+[models."grok-2-image"]
+routing = ["xai"]
+endpoints = ["image_generation"]
+
+[models."grok-2-image".providers.xai]
+type = "xai"
+model_name = "grok-2-image"
+api_key_location = { env = "XAI_API_KEY" }
+```
+
+### API Usage
+
+xAI's image generation follows the OpenAI-compatible format:
+
+```bash
+# Generate an image
+curl -X POST http://localhost:3000/v1/images/generations \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "grok-2-image",
+    "prompt": "A futuristic city at sunset",
+    "n": 1,
+    "response_format": "url"
+  }'
+```
+
+### Implementation Details
+
+1. **Provider Implementation**: `XAIProvider` implements the `ImageGenerationProvider` trait
+2. **Endpoint**: Uses xAI's OpenAI-compatible endpoint: `https://api.x.ai/v1/images/generations`
+3. **Authentication**: Uses the same API key configuration as chat completions
+4. **Response Format**: Returns standard OpenAI image response format with URLs or base64 data
+
+### Supported Parameters
+
+xAI supports a subset of OpenAI's image generation parameters:
+- `model`: Always "grok-2-image"
+- `prompt`: Required string describing the image to generate
+- `n`: Number of images to generate (1-10, default: 1)
+- `response_format`: "url" or "b64_json" (default: "url")
+- `user`: Optional string for abuse monitoring
+
+### Limitations
+
+Unlike OpenAI's DALL-E models, xAI currently doesn't support:
+- `quality`: Not supported by xAI API
+- `size`: Not supported by xAI API  
+- `style`: Not supported by xAI API
+
+These parameters are ignored gracefully if provided.
+
+### Error Handling
+
+The xAI provider includes comprehensive error handling for:
+- Rate limiting (5 requests/second)
+- Invalid prompts or content policy violations
+- Network timeouts and connection issues
+- Authentication failures
+
+### Testing
+
+```bash
+# Run unit tests for xAI image generation
+cargo test --package tensorzero-internal test_xai_image
+
+# Run all xAI provider tests
+cargo test --package tensorzero-internal --lib xai
+```
+
+### Future Enhancements
+
+Potential improvements that could be added when xAI expands their API:
+- Image size control
+- Quality settings
+- Style parameters
+- Batch processing optimizations

--- a/tensorzero-internal/src/auth.rs
+++ b/tensorzero-internal/src/auth.rs
@@ -18,9 +18,8 @@ pub struct ApiKeyMetadata {
 pub type APIConfig = HashMap<String, ApiKeyMetadata>;
 
 // Common error response helper
-fn auth_error_response(status: StatusCode, error_type: &str, message: &str) -> Response {
+fn auth_error_response(status: StatusCode, _error_type: &str, message: &str) -> Response {
     let body = serde_json::json!({
-        "type": error_type,
         "error": message
     });
     (status, axum::Json(body)).into_response()
@@ -131,7 +130,7 @@ pub async fn require_api_key(
             return Err(auth_error_response(
                 StatusCode::NOT_FOUND,
                 "model_not_found",
-                "Model not found in API key",
+                &format!("Model not found: {}", model),
             ))
         }
     };

--- a/tensorzero-internal/src/endpoints/openai_compatible.rs
+++ b/tensorzero-internal/src/endpoints/openai_compatible.rs
@@ -2730,10 +2730,9 @@ pub async fn image_generation_handler(
     {
         Ok(Some(model)) => model,
         Ok(None) => {
-            // Model doesn't exist - return 404 using RouteNotFound
-            return Err(Error::new(ErrorDetails::RouteNotFound {
-                path: "/v1/images/generations".to_string(),
-                method: "POST".to_string(),
+            // Model doesn't exist - return 404 with ModelNotFound error
+            return Err(Error::new(ErrorDetails::ModelNotFound {
+                name: model_name.to_string(),
             }));
         }
         Err(e) => {

--- a/tensorzero-internal/src/error.rs
+++ b/tensorzero-internal/src/error.rs
@@ -313,6 +313,9 @@ pub enum ErrorDetails {
     OutputValidation {
         source: Box<Error>,
     },
+    ModelNotFound {
+        name: String,
+    },
     ProviderNotFound {
         provider_name: String,
     },
@@ -466,6 +469,7 @@ impl ErrorDetails {
             ErrorDetails::Observability { .. } => tracing::Level::ERROR,
             ErrorDetails::OutputParsing { .. } => tracing::Level::WARN,
             ErrorDetails::OutputValidation { .. } => tracing::Level::WARN,
+            ErrorDetails::ModelNotFound { .. } => tracing::Level::WARN,
             ErrorDetails::ProviderNotFound { .. } => tracing::Level::ERROR,
             ErrorDetails::Serialization { .. } => tracing::Level::ERROR,
             ErrorDetails::StreamError { .. } => tracing::Level::ERROR,
@@ -561,6 +565,7 @@ impl ErrorDetails {
             ErrorDetails::Observability { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::OutputParsing { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::OutputValidation { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+            ErrorDetails::ModelNotFound { .. } => StatusCode::NOT_FOUND,
             ErrorDetails::ProviderNotFound { .. } => StatusCode::NOT_FOUND,
             ErrorDetails::Serialization { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorDetails::StreamError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
@@ -925,6 +930,9 @@ impl std::fmt::Display for ErrorDetails {
             }
             ErrorDetails::OutputValidation { source } => {
                 write!(f, "Output validation failed with messages: {source}")
+            }
+            ErrorDetails::ModelNotFound { name } => {
+                write!(f, "Model not found: {name}")
             }
             ErrorDetails::ProviderNotFound { provider_name } => {
                 write!(f, "Provider not found: {provider_name}")

--- a/tensorzero-internal/src/model.rs
+++ b/tensorzero-internal/src/model.rs
@@ -2070,6 +2070,11 @@ impl ModelProvider {
                     .generate_image(request, client, dynamic_api_keys)
                     .await
             }
+            ProviderConfig::XAI(provider) => {
+                provider
+                    .generate_image(request, client, dynamic_api_keys)
+                    .await
+            }
             #[cfg(any(test, feature = "e2e_tests"))]
             ProviderConfig::Dummy(provider) => {
                 provider


### PR DESCRIPTION
## Summary

This PR adds image generation capabilities to the xAI provider, enabling support for the `grok-2-image` model through TensorZero's unified `/v1/images/generations` endpoint.

Closes #47

## What's Changed

### ✨ Core Features
- **xAI Image Generation**: Implemented `ImageGenerationProvider` trait for the xAI provider
- **Request/Response Types**: Added xAI-specific types for proper API communication
- **Model Routing**: Integrated xAI into the image generation routing system
- **Full Parameter Support**: Supports all xAI-accepted parameters (model, prompt, n, response_format, user)

### 🐛 Bug Fixes
- **Better Error Messages**: Fixed misleading "Route not found" error when model doesn't exist
- **Consistent Error Format**: Unified error response format across auth middleware and regular endpoints
- **New Error Type**: Added `ModelNotFound` error for clearer user feedback

### 📚 Documentation
- Updated CLAUDE.md with comprehensive xAI image generation section
- Added configuration examples and API usage documentation
- Documented limitations and supported parameters

## Technical Details

### API Specifications
- **Model**: `grok-2-image`
- **Endpoint**: `https://api.x.ai/v1/images/generations`
- **Rate Limits**: 5 requests/second, up to 10 images per request
- **Pricing**: $0.07 per image

### Supported Parameters
- `model`: Always "grok-2-image"
- `prompt`: Required string describing the image
- `n`: Number of images (1-10, default: 1)
- `response_format`: "url" or "b64_json" (default: "url")
- `user`: Optional string for abuse monitoring

### Limitations
xAI currently doesn't support:
- `quality` parameter
- `size` parameter
- `style` parameter

These parameters are gracefully ignored if provided.

## Example Configuration

```toml
[models."grok-2-image"]
routing = ["xai"]
endpoints = ["image_generation"]

[models."grok-2-image".providers.xai]
type = "xai"
model_name = "grok-2-image"
api_key_location = { env = "XAI_API_KEY" }
```

## Example Usage

```bash
curl -X POST http://localhost:3000/v1/images/generations \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "grok-2-image",
    "prompt": "A futuristic city at sunset",
    "n": 1,
    "response_format": "url"
  }'
```

## Testing

### Unit Tests
- ✅ Request/response serialization
- ✅ URL generation 
- ✅ Error handling
- ✅ All existing tests pass

### Manual Testing
- ✅ Invalid model returns: `{"error": "Model not found: invalid-model"}`
- ✅ Valid model with dummy API key returns appropriate auth error
- ✅ Model without image capability returns capability error

## Implementation Pattern

This implementation follows the established pattern from the Together provider, ensuring consistency across the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)